### PR TITLE
BAH-1898 | Fix. Remove hardcoding of schema name in Liquibase

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -13,12 +13,14 @@ env:
 jobs:
   build-publish:
     name: Build & Publish
-    # MySQL dist 5.7 comes preinstalled on ubuntu-18.04. Ubuntu-latest have dist 20.x
-    runs-on: ubuntu-18.04
-    env:
-      DB_DATABASE: reports_integration_tests
-      DB_USER: root
-      DB_PASSWORD: root
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
@@ -37,17 +39,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-# OpenMRS 2.1.6 and its corresponding schema dump is on MySql 5.6. There are breaking changes between 5.6 and 5.7
-# e.g. only_full_group_by is enabled by default
-# We are mutating global and session sql_mode as workaround to make 5.7 almost similar to 5.6 
-# since there isnt any official Ubuntu image supported by GHA that runs mysql 5.6
-# POst OMRS upgrade to 2.5, this needs to be revisited
-      - name: start MySQL
-        run: |
-          sudo systemctl start mysql.service
-          mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
-          mysql -uroot -proot reports_integration_tests -e "set global sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';"
-          mysql -uroot -proot reports_integration_tests -e "set session sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';"
       - name: Test and Package
         run:
           ./mvnw -T 4 --no-transfer-progress -DskipDump=false -DskipConfig=false clean package

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -10,6 +10,13 @@ jobs:
       DB_DATABASE: reports_integration_tests
       DB_USER: root
       DB_PASSWORD: root
+    services:
+      mysql:
+        image: mysql:5.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
     steps:
       - name: Setup Java 8
         uses: actions/setup-java@v2
@@ -18,9 +25,5 @@ jobs:
           java-version: '8'
       - name: Checkout Repository
         uses: actions/checkout@v2
-      - uses: shogo82148/actions-setup-mysql@v1
-        with:
-          mysql-version: '5.6'
-          root-password: 'root'
       - name: Test and build package
         run: ./mvnw -T 4 --no-transfer-progress -DskipDump=false -DskipConfig=false clean install

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -6,10 +6,6 @@ jobs:
   build-package:
     name: Build Package
     runs-on: ubuntu-latest
-    env:
-      DB_DATABASE: reports_integration_tests
-      DB_USER: root
-      DB_PASSWORD: root
     services:
       mysql:
         image: mysql:5.6

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build-package:
     name: Build Package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       DB_DATABASE: reports_integration_tests
       DB_USER: root

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -18,16 +18,9 @@ jobs:
           java-version: '8'
       - name: Checkout Repository
         uses: actions/checkout@v2
-# OpenMRS 2.1.6 and its corresponding schema dump is on MySql 5.6. There are breaking changes between 5.6 and 5.7
-# e.g. only_full_group_by is enabled by default
-# We are mutating global and session sql_mode as workaround to make 5.7 almost similar to 5.6
-# since there isnt any official Ubuntu image supported by GHA that runs mysql 5.6
-# POst OMRS upgrade to 2.5, this needs to be revisited
-      - name: start MySQL
-        run: |
-          sudo systemctl start mysql.service
-          mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
-          mysql -uroot -proot reports_integration_tests -e "set global sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';"
-          mysql -uroot -proot reports_integration_tests -e "set session sql_mode='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';"
+      - uses: shogo82148/actions-setup-mysql@v1
+        with:
+          mysql-version: '5.6'
+          root-password: 'root'
       - name: Test and build package
         run: ./mvnw -T 4 --no-transfer-progress -DskipDump=false -DskipConfig=false clean install

--- a/src/main/resources/liquibase.xml
+++ b/src/main/resources/liquibase.xml
@@ -99,8 +99,8 @@
             VALUES ('Reports User', 1, now(),@person_id, uuid(), 'reports-user','29171af2d2cc6b48ab011c6387daa8516960edd0a7fa4e8bc6eaf1aab1d3d15443a82213fb0d11b3071ca73d45f719d885b2fdabcfef03b54b3102af450cd771','6bc56cf15a664f951134af3451ac806e746215fa3e482b72f08a911e848962bee8b124e672f3cbe8dc7040dc6d8e35960e24a1ffa6150af63d12ba1ce8c07fad');
         </sql>
     </changeSet>
-    <changeSet id="Reports-2211201660456" author="Ravindra, Salauddin">
-        <sql>DROP FUNCTION IF EXISTS openmrs.obsParent</sql>
+    <changeSet id="Reports-2211201660456-updated" author="Ravindra, Salauddin">
+        <sql>DROP FUNCTION IF EXISTS obsParent</sql>
         <sql splitStatements="false" stripComments="false">
             <![CDATA[
               CREATE FUNCTION `obsParent`(obsid int) RETURNS int(11)


### PR DESCRIPTION
- Removed Hardcoding of schema name in Liquibase migration
- Use mysql 5.6 as a service container to fix the build time. 