### PR TITLE
BAH-2436 | Use amazoncorretto as base image

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: '8'
       - name: Test and Package
         run:

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -32,7 +32,7 @@ jobs:
           ./setArtifactVersion.sh
           rm setArtifactVersion.sh
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
           java-version: '8'

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Java 8
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: '8'
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -15,7 +15,7 @@ jobs:
           - 3306:3306
     steps:
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
           java-version: '8'

--- a/package/docker/bahmni-reports/Dockerfile
+++ b/package/docker/bahmni-reports/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM amazoncorretto:8
 
 ENV SERVER_PORT=8051
 ENV BASE_DIR=/var/run/bahmni-reports
@@ -14,10 +14,10 @@ RUN mkdir -p ${HOME}/.bahmni-reports/
 RUN mkdir -p /var/log/bahmni-reports/
 RUN mkdir -p /tmp/artifacts/default_config/
 RUN mkdir -p /etc/bahmni_config/reports/
-RUN apt-get update && apt-get install gettext-base
+RUN yum install -y gettext unzip
 
 ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for /etc/wait-for
-RUN apt-get install -y netcat
+RUN yum install -y nc
 RUN chmod +x /etc/wait-for
 
 COPY target/bahmnireports.war /etc/bahmni-reports/bahmnireports.war


### PR DESCRIPTION
Using amazoncorreto as baseimage since openjdk builds has beeen deprecated. More info [here](https://talk.openmrs.org/t/using-amazoncorretto-as-base-image-for-bahmni-docker-images/37668).

Co-authored-by: Divij Goyal <divij.g@beehyv.com>