### PR TITLE
[Rahul] | BAH-3005 | Add. Timezone Global Value For Helm Charts

### DIFF
--- a/package/helm/templates/configMap.yaml
+++ b/package/helm/templates/configMap.yaml
@@ -7,3 +7,4 @@ data:
   OPENMRS_HOST: "{{ .Values.config.OPENMRS_HOST }}"
   OPENMRS_PORT: "{{ .Values.config.OPENMRS_PORT }}"
   REPORTS_DB_NAME: "{{ .Values.config.REPORTS_DB_NAME }}"
+  TZ: "{{ .Values.global.TZ }}"

--- a/package/helm/values.yaml
+++ b/package/helm/values.yaml
@@ -2,6 +2,7 @@ global:
   nodeSelector: {}
   affinity: {}
   tolerations: {}
+  TZ: "UTC"
 
 replicaCount: 1
 


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

In this PR, we have added the TZ environment variable to the helm charts to configure the timezone for the [bahmni-reports](https://github.com/Bahmni/bahmni-reports) container.