### PR TITLE
BAH-3160 | Add. amazoncorretto:11 As Docker Base Image

### DIFF
--- a/package/docker/bahmni-reports/Dockerfile
+++ b/package/docker/bahmni-reports/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:8
+FROM amazoncorretto:11
 
 ENV SERVER_PORT=8051
 ENV BASE_DIR=/var/run/bahmni-reports
@@ -15,7 +15,10 @@ RUN mkdir -p /var/log/bahmni-reports/
 RUN yum install -y gettext unzip
 
 ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for /etc/wait-for
-RUN yum install -y nc
+RUN yum install -y nc \
+    elfutils-libelf-0.176-2.amzn2.0.1 \
+    libnghttp2-1.41.0-1.amzn2.0.1
+
 RUN chmod +x /etc/wait-for
 
 COPY target/bahmnireports.war /etc/bahmni-reports/bahmnireports.war


### PR DESCRIPTION
In this PR, the following modifications have been implemented:

1. **Base Image Update**: The base image `amazoncorretto` has been upgraded from version 8 to version 11. 
2. **Vulnerability Fixes**: To mitigate potential security risks, specific versions of packages `elfutils-libelf` and `libnghttp2` have been installed. These updates address known vulnerabilities, bolstering the overall security posture of the project