### PR TITLE
BAH-3376 | Introduce environment variable for Odoo DB name

### DIFF
--- a/package/docker/bahmni-reports/template/bahmni-reports.properties.template
+++ b/package/docker/bahmni-reports/template/bahmni-reports.properties.template
@@ -13,7 +13,7 @@ openmrs.service.password=Admin123
 openmrs.connectionTimeoutInMilliseconds=30000
 openmrs.replyTimeoutInMilliseconds=120000
 macrotemplates.temp.directory=/tmp/
-openerp.url=jdbc:postgresql://${ODOO_DB_SERVER}:5432/odoo
+openerp.url=jdbc:postgresql://${ODOO_DB_SERVER}:5432/${ODOO_DB_NAME}
 openerp.username= ${ODOO_DB_USERNAME}
 openerp.password=${ODOO_DB_PASSWORD}
 bahmnireports.db.url=jdbc:mysql://${REPORTS_DB_SERVER}:3306/${REPORTS_DB_NAME}?allowMultiQueries=true


### PR DESCRIPTION
This PR introduces an environment variable for configuring Odoo DB name for running reports of the type `ERPGeneric`.