### PR TITLE
BAH-4708: Fix Spring Framework path traversal vulnerabilities

### DIFF
--- a/package/docker/bahmni-reports/Dockerfile
+++ b/package/docker/bahmni-reports/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:11
+FROM amazoncorretto:21
 
 ENV SERVER_PORT=8051
 ENV BASE_DIR=/var/run/bahmni-reports
@@ -15,9 +15,9 @@ RUN mkdir -p /var/log/bahmni-reports/
 RUN yum install -y gettext unzip
 
 ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for /etc/wait-for
-RUN yum install -y nc \
-    elfutils-libelf-0.176-2.amzn2.0.1 \
-    libnghttp2-1.41.0-1.amzn2.0.1
+RUN yum install -y --security nc \
+    elfutils-libelf \
+    libnghttp2
 
 RUN chmod +x /etc/wait-for
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>1.2.0-SNAPSHOT</version>
 
     <properties>
-        <spring.version>6.0.14</spring.version>
+        <spring.version>6.2.19</spring.version>
         <dynamicreports.version>4.0.0</dynamicreports.version>
         <jackson.version>2.17.0</jackson.version>
         <skipDump>true</skipDump>
@@ -62,8 +62,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <target>11</target>
-                        <source>11</source>
+                        <target>17</target>
+                        <source>17</source>
                         <compilerArgument>-proc:none</compilerArgument>
 
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>1.2.0-SNAPSHOT</version>
 
     <properties>
-        <spring.version>5.3.39</spring.version>
+        <spring.version>6.0.14</spring.version>
         <dynamicreports.version>4.0.0</dynamicreports.version>
         <jackson.version>2.17.0</jackson.version>
         <skipDump>true</skipDump>


### PR DESCRIPTION
Upgrade Spring to 6.2.19 to fix CVE-2024-38816, CVE-2024-22243, CVE-2024-22262 and 13 additional security issues. Update Java compiler target to 17 to match Spring 6.2 requirements. Uses Amazon Corretto 21 LTS base image.