### PR TITLE
Fix Dockerfile - remove pinned yum package versions unavailable in Amazon Linux 2

### DIFF
--- a/package/docker/bahmni-reports/Dockerfile
+++ b/package/docker/bahmni-reports/Dockerfile
@@ -16,8 +16,8 @@ RUN yum install -y gettext unzip
 
 ADD https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for /etc/wait-for
 RUN yum install -y nc \
-    elfutils-libelf-0.176-2.amzn2.0.1 \
-    libnghttp2-1.41.0-1.amzn2.0.1
+    elfutils-libelf \
+    libnghttp2
 
 RUN chmod +x /etc/wait-for
 


### PR DESCRIPTION
## Problem

Docker build was failing with:
```
No match for argument: elfutils-libelf-0.176-2.amzn2.0.1
No match for argument: libnghttp2-1.41.0-1.amzn2.0.1
Error: Unable to find a match
```

These specific package versions have been removed from the Amazon Linux 2 YUM repository.

## Fix

Removed version pins from the two packages. Installing without version constraints picks up the latest available versions in the Amazon Linux 2 repo, which include all the same security patches.

```dockerfile
# Before
RUN yum install -y nc \
    elfutils-libelf-0.176-2.amzn2.0.1 \
    libnghttp2-1.41.0-1.amzn2.0.1

# After
RUN yum install -y nc \
    elfutils-libelf \
    libnghttp2
```

## No regression risk

Only the version pins are removed. The packages themselves (`nc`, `elfutils-libelf`, `libnghttp2`) are still installed. Amazon Linux 2 ships patched versions of these packages.